### PR TITLE
FIX: set autocomplete value to nope io off

### DIFF
--- a/packages/ngx-forms/src/lib/auto-complete/components/auto-complete/auto-complete.component.html
+++ b/packages/ngx-forms/src/lib/auto-complete/components/auto-complete/auto-complete.component.html
@@ -14,7 +14,7 @@
          aria-autocomplete="list"
          auiFlyoutAction
          auiSelectableActions
-         autocomplete="nope"
+         [autocomplete]="autoComplete"
          type="text"
   />
   <input (focus)="onFocus()"
@@ -32,7 +32,7 @@
          aria-autocomplete="list"
          auiFlyoutAction
          auiSelectableActions
-         autocomplete="nope"
+         [autocomplete]="autoComplete"
          type="text"
   />
 

--- a/packages/ngx-forms/src/lib/auto-complete/components/auto-complete/auto-complete.component.html
+++ b/packages/ngx-forms/src/lib/auto-complete/components/auto-complete/auto-complete.component.html
@@ -14,7 +14,7 @@
          aria-autocomplete="list"
          auiFlyoutAction
          auiSelectableActions
-         autocomplete="off"
+         autocomplete="nope"
          type="text"
   />
   <input (focus)="onFocus()"
@@ -32,7 +32,7 @@
          aria-autocomplete="list"
          auiFlyoutAction
          auiSelectableActions
-         autocomplete="off"
+         autocomplete="nope"
          type="text"
   />
 

--- a/packages/ngx-forms/src/lib/auto-complete/components/auto-complete/auto-complete.component.ts
+++ b/packages/ngx-forms/src/lib/auto-complete/components/auto-complete/auto-complete.component.ts
@@ -44,6 +44,7 @@ export class AutoCompleteComponent implements ControlValueAccessor, OnInit, OnCh
   @Input() loadingText: string;
   @Input() noResultsText: string;
   @Input() showAllByDefault = false;
+  @Input() autoComplete = 'off';
 
   // specify which label/value props to use
   @Input() label: string;


### PR DESCRIPTION
## PR Checklist

This PR fulfills the following requirements:


- [ x ] The commit message follows our guidelines: [Contributing guidelines](https://github.com/digipolisantwerp/antwerp-ui_angular/blob/master/CONTRIBUTING.md)
- [ x ] Tests for the changes have been added (for bug fixes / features)
- [ x ] Docs have been added / updated (for bug fixes / features)
- [ x ] A [changelog entry](https://github.com/digipolisantwerp/antwerp-ui_angular/blob/master/guidelines/CHANGELOG.md) was added

## PR Type

What kind of change does this PR introduce?

- [ x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Autocomplete="off" attribute is ignored by Chrome. 
https://jira.antwerpen.be/browse/SGWET-4973
https://stackoverflow.com/questions/12374442/chrome-ignores-autocomplete-off


Issue Number: N/A

## What is the new behavior?
Autocomplete is no longer shown.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ x ] No

## Other information

## Resolved issues

<!--
See https://help.github.com/articles/closing-issues-using-keywords/ for more info
Closes: #123
Fixes: #123
Resolves: #123
-->
