### PR TITLE
FIX:  Value could not be determined statically.

### DIFF
--- a/packages/ngx-forms/src/lib/datepicker/datepicker.module.ts
+++ b/packages/ngx-forms/src/lib/datepicker/datepicker.module.ts
@@ -37,7 +37,7 @@ export class DatepickerModule {
     weekdayLabels: string[],
     monthLabels: string[],
     errorLabels: DatepickerErrorLabels
-  ): ModuleWithProviders<any> {
+  ): ModuleWithProviders<DatepickerModule> {
     return {
       ngModule: DatepickerModule,
       providers: [


### PR DESCRIPTION
This commit fixes the error Value could not be determined statically when DatepickerModule is imported with .forChild() for configuration purposes.

## PR Checklist

This PR fulfills the following requirements:
<!-- Please put "[x]" for requirements that this PR satisfies. -->

- [x] The commit message follows our guidelines: [Contributing guidelines](https://github.com/digipolisantwerp/antwerp-ui_angular/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] A [changelog entry](https://github.com/digipolisantwerp/antwerp-ui_angular/blob/master/guidelines/CHANGELOG.md) was added

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## Resolved issues

<!--
See https://help.github.com/articles/closing-issues-using-keywords/ for more info
Closes: #123
Fixes: #123
Resolves: #123
-->
